### PR TITLE
[Tags] CustomCommands Conversion

### DIFF
--- a/tags/__init__.py
+++ b/tags/__init__.py
@@ -38,6 +38,7 @@ def setup(bot: Red) -> None:
     cog = bot.get_cog("CustomCommands")
     if cog:
         raise CogLoadError(
-            "This cog conflicts with CustomCommands and cannot be loaded with both at the same time."
+            "This cog conflicts with CustomCommands and both cannot be loaded at the same time. "
+            "After unloading `customcom`, you can migrate custom commands to tags with `[p]migratecustomcom`."
         )
     bot.add_cog(Tags(bot))

--- a/tags/blocks/__init__.py
+++ b/tags/blocks/__init__.py
@@ -22,10 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
+from .customcom import ContextVariableBlock, ConverterBlock
 from .delete import DeleteBlock
 from .react import ReactBlock, ReactUBlock
 from .silent import SilentBlock
-from .customcom import ContextVariableBlock, ConverterBlock
 
 __all__ = (
     "DeleteBlock",

--- a/tags/blocks/customcom.py
+++ b/tags/blocks/customcom.py
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import Optional
 import re
 
 from TagScriptEngine import Block, Context
 
 CONVERTER_RE = re.compile(r"(?i)(\d{1,2})(?:\.[a-z]+)?(?::[a-z]+)?")
+
 
 class ContextVariableBlock(Block):
     def will_accept(self, ctx: Context) -> bool:
@@ -38,6 +38,7 @@ class ContextVariableBlock(Block):
         dec = ctx.verb.declaration.lower().split(".", 1)
         parameter = f"({dec[1]})" if len(dec) == 2 else ""
         return "{%s%s}" % (dec[0], parameter)
+
 
 class ConverterBlock(Block):
     def will_accept(self, ctx: Context) -> bool:

--- a/tags/blocks/customcom.py
+++ b/tags/blocks/customcom.py
@@ -22,16 +22,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from .delete import DeleteBlock
-from .react import ReactBlock, ReactUBlock
-from .silent import SilentBlock
-from .customcom import ContextVariableBlock, ConverterBlock
+from typing import Optional
+import re
 
-__all__ = (
-    "DeleteBlock",
-    "SilentBlock",
-    "ReactBlock",
-    "ReactUBlock",
-    "ContextVariableBlock",
-    "ConverterBlock",
-)
+from TagScriptEngine import Block, Context
+
+CONVERTER_RE = re.compile(r"(?i)(\d{1,2})(?:\.[a-z]+)?(?::[a-z]+)?")
+
+class ContextVariableBlock(Block):
+    def will_accept(self, ctx: Context) -> bool:
+        dec = ctx.verb.declaration.lower().split(".", 1)[0]
+        return dec in ("author", "channel", "server", "guild")
+
+    def process(self, ctx: Context) -> str:
+        dec = ctx.verb.declaration.lower().split(".", 1)
+        parameter = f"({dec[1]})" if len(dec) == 2 else ""
+        return "{%s%s}" % (dec[0], parameter)
+
+class ConverterBlock(Block):
+    def will_accept(self, ctx: Context) -> bool:
+        return bool(CONVERTER_RE.match(ctx.verb.declaration))
+
+    def process(self, ctx: Context) -> str:
+        match = CONVERTER_RE.match(ctx.verb.declaration)
+        num = match.group(1)
+        return "{args(%s)}" % num

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -660,7 +660,7 @@ class Commands(MixinMeta):
             migrated_guilds += 1
             for name, command in guild_data["commands"].items():
                 if not command:
-                    continue # some keys in custom commands config are None instead of being deleted
+                    continue  # some keys in custom commands config are None instead of being deleted
                 try:
                     tag = self.convert_customcommand(guild_id, name, command)
                 except Exception as exc:

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -597,11 +597,7 @@ class Commands(MixinMeta):
             )
             await global_tag.initialize()
             migrated_global_alias += 1
-        await ctx.send(
-            f"Migrated {migrated_global_alias} global aliases to tags. "
-            "Migration completed, unload the alias cog to prevent command "
-            f"duplication with `{ctx.clean_prefix}unload alias`."
-        )
+        await ctx.send(f"Migrated {migrated_global_alias} global aliases to tags.")
 
     def parse_cc_text(self, content: str) -> str:
         # TODO tse.build_node_tree to find converters

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -28,6 +28,7 @@ import time
 import types
 from typing import Dict, List, Optional, Set, Union
 from urllib.parse import quote_plus
+import logging
 
 import bs4
 import discord
@@ -59,6 +60,7 @@ TAG_RE = re.compile(r"(?i)(\[p\])?\btag'?s?\b")
 
 DOCS_URL = "https://phen-cogs.readthedocs.io/en/latest/"
 
+log = logging.getLogger("red.phenom4n4n.tags.commands")
 
 def _sub(match: re.Match) -> str:
     if match.group(1):
@@ -656,7 +658,11 @@ class Commands(MixinMeta):
                 continue
             migrated_guilds += 1
             for name, command in guild_data["commands"].items():
-                tag = self.convert_customcommand(guild_id, name, command)
+                try:
+                    tag = self.convert_customcommand(guild_id, name, command)
+                except Exception as exc:
+                    log.exception("An exception occured while converting custom command %s (%r) from guild %s" % (name, command, guild_id), exc_info=exc)
+                    return await ctx.send(f"An exception occured while converting custom command `{name}` from server {guild_id}. Check your logs for more details")
                 await tag.initialize()
                 migrated_ccs += 1
         await ctx.send(

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -658,6 +658,8 @@ class Commands(MixinMeta):
                 continue
             migrated_guilds += 1
             for name, command in guild_data["commands"].items():
+                if not command:
+                    continue # some keys in custom commands config are None instead of being deleted
                 try:
                     tag = self.convert_customcommand(guild_id, name, command)
                 except Exception as exc:

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -606,7 +606,7 @@ class Commands(MixinMeta):
         return tagscript
 
     def convert_customcommand(self, guild_id: int, name: str, custom_command: dict) -> Tag:
-        author_id = custom_command["author"]["id"]
+        author_id = custom_command.get("author", {"id": None})["id"]
         response = custom_command["response"]
         if isinstance(response, str):
             tagscript = self.parse_cc_text(response)

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -559,8 +559,8 @@ class Commands(MixinMeta):
         migrated_guilds = 0
         migrated_guild_alias = 0
         alias_config = Config.get_conf(
-            None, 8927348724, cog_name="Alias" # core cog doesn't use force_registration=True smh
-        ) # Red can't change these values without breaking data 
+            None, 8927348724, cog_name="Alias"  # core cog doesn't use force_registration=True smh
+        )  # Red can't change these values without breaking data
         # so while this is sus it is technically safe to use
         all_guild_data: dict = await alias_config.all_guilds()
 
@@ -645,7 +645,7 @@ class Commands(MixinMeta):
             return await ctx.send("Query timed out, not migrating CustomCommands to tags.")
         if pred.result is False:
             return await ctx.send("Migration cancelled.")
-        
+
         cc_config = Config.get_conf(None, 414589031223512, cog_name="CustomCommands")
         migrated_guilds = 0
         migrated_ccs = 0

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -23,12 +23,12 @@ SOFTWARE.
 """
 
 import asyncio
+import logging
 import re
 import time
 import types
 from typing import Dict, List, Optional, Set, Union
 from urllib.parse import quote_plus
-import logging
 
 import bs4
 import discord
@@ -61,6 +61,7 @@ TAG_RE = re.compile(r"(?i)(\[p\])?\btag'?s?\b")
 DOCS_URL = "https://phen-cogs.readthedocs.io/en/latest/"
 
 log = logging.getLogger("red.phenom4n4n.tags.commands")
+
 
 def _sub(match: re.Match) -> str:
     if match.group(1):
@@ -663,8 +664,14 @@ class Commands(MixinMeta):
                 try:
                     tag = self.convert_customcommand(guild_id, name, command)
                 except Exception as exc:
-                    log.exception("An exception occured while converting custom command %s (%r) from guild %s" % (name, command, guild_id), exc_info=exc)
-                    return await ctx.send(f"An exception occured while converting custom command `{name}` from server {guild_id}. Check your logs for more details")
+                    log.exception(
+                        "An exception occured while converting custom command %s (%r) from guild %s"
+                        % (name, command, guild_id),
+                        exc_info=exc,
+                    )
+                    return await ctx.send(
+                        f"An exception occured while converting custom command `{name}` from server {guild_id}. Check your logs for more details"
+                    )
                 await tag.initialize()
                 migrated_ccs += 1
         await ctx.send(

--- a/tags/commands.py
+++ b/tags/commands.py
@@ -570,6 +570,7 @@ class Commands(MixinMeta):
             None, 8927348724, cog_name="Alias"  # core cog doesn't use force_registration=True smh
         )  # Red can't change these values without breaking data
         # so while this is sus it is technically safe to use
+        alias_config.register_global(entries=[])
         all_guild_data: dict = await alias_config.all_guilds()
 
         async for guild_data in AsyncIter(all_guild_data.values(), steps=100):
@@ -577,7 +578,7 @@ class Commands(MixinMeta):
                 continue
             migrated_guilds += 1
             for alias in guild_data["entries"]:
-                tagscript = "{c:" + alias["command"] + " {args}}"
+                tagscript = "{c:%s {args}}" % alias["command"]
                 tag = Tag(
                     self,
                     alias["name"],
@@ -595,7 +596,7 @@ class Commands(MixinMeta):
 
         migrated_global_alias = 0
         async for entry in AsyncIter(await alias_config.entries(), steps=50):
-            tagscript = "{c:" + entry["command"] + " {args}}"
+            tagscript = "{c:%s {args}}" % entry["command"]
             global_tag = Tag(
                 self,
                 entry["name"],
@@ -622,11 +623,11 @@ class Commands(MixinMeta):
             indices = []
             for index, response_text in enumerate(response, 1):
                 script = self.parse_cc_text(response_text)
-                tag_lines.append("{=(choice_" + str(index) + "):" + script + "}")
+                tag_lines.append("{=(choice.%s):%s}" % (index, script))
                 indices.append(index)
-            random_block = "{#:" + ",".join(str(i) for i in indices) + "}"
-            tag_lines.append("{=(chosen):" + random_block + "}")
-            tag_lines.append("{choice_{chosen}}")
+            random_block = "{#:%s}" % ",".join(str(i) for i in indices)
+            tag_lines.append("{=(chosen):%s}" % random_block)
+            tag_lines.append("{choice.{chosen}}")
             tagscript = "\n".join(tag_lines)
         return Tag(self, name, tagscript, guild_id=guild_id, author_id=author_id)
 

--- a/tags/core.py
+++ b/tags/core.py
@@ -56,7 +56,7 @@ class Tags(
     The TagScript documentation can be found [here](https://phen-cogs.readthedocs.io/en/latest/).
     """
 
-    __version__ = "2.2.6"
+    __version__ = "2.2.7"
 
     def format_help_for_context(self, ctx: commands.Context):
         pre_processed = super().format_help_for_context(ctx)

--- a/tags/info.json
+++ b/tags/info.json
@@ -3,7 +3,7 @@
     "short": "Create and use tags.",
     "description": "Create and use tags.",
     "end_user_data_statement": "This cog stores End User Data when storing the author of a tag. If a user requests data-deletion, all their tags will be removed from the bot.",
-    "install_msg": "Thanks for installing Tags!\nGet started by reading the documentation found here.\n<https://phen-cogs.readthedocs.io/en/latest/>\n\nThis cog has features that allow users to run commands within a tag. Having this loaded with `customcom` or `alias` can result in infinite looping, so having both loaded at once is not recommended.",
+    "install_msg": "Thanks for installing Tags!\nGet started by reading the documentation found here.\n<https://phen-cogs.readthedocs.io/en/latest/>\nThis cog's behavior conflicts with Alias and CustomCommands and can cause duplicate bot responses if misused. It is recommended to unload and migrate them to tags with `[p]migratealias` and `[p]migratecustomcom`.",
     "author": [
         "PhenoM4n4n"
     ],

--- a/tags/objects.py
+++ b/tags/objects.py
@@ -171,6 +171,8 @@ class Tag:
             )
         elif alias in self.aliases:
             raise TagAliasError(f"`{alias}` is already an alias for `{self}`.")
+        elif aliased_tag := self.cache_path.get(alias):
+            raise TagAliasError(f"`{alias}` is already an alias for `{aliased_tag}`.")
 
         self._aliases.append(alias)
         self.cache_path[alias] = self

--- a/tags/processor.py
+++ b/tags/processor.py
@@ -136,7 +136,7 @@ class Processor(MixinMeta):
 
             if actions.get("commands"):
                 for command in actions["commands"]:
-                    if command.startswith("tag") or command == "invoketag":
+                    if command == "invoketag":
                         await ctx.send("Tag looping isn't allowed.")
                         return
                     new = copy(ctx.message)


### PR DESCRIPTION
Adds support for converting custom commands from the Core CustomCommnads cog into tags. This handles randomized custom commands by wrapping the responses into random blocks. It also replaces converters with the loose `{args(int)}` block.

Additionally, both `migratealias` and `migratecustomcom` work with the Alias and CustomCommands cogs unloaded.