### PR TITLE
Add a leaderboard to typeracer

### DIFF
--- a/typeracer/info.json
+++ b/typeracer/info.json
@@ -2,14 +2,16 @@
     "name": "TypeRacer",
     "short": "Race to see who can type the fastest!",
     "description": "Race to see who can type the fastest!",
-    "end_user_data_statement": "This cog does not persistently store any data or metadata about users.",
+    "end_user_data_statement": "Phen update this to what you would like it to be",
     "install_msg": "Thanks for installing TypeRacer! The original credits for this cog go to Cats3153.",
     "author": [
         "Cats3153",
         "PhenoM4n4n"
     ],
     "required_cogs": {},
-    "requirements": ["Pillow"],
+    "requirements": [
+        "Pillow"
+    ],
     "tags": [
         "fun",
         "game",


### PR DESCRIPTION
I made some changes to the typeracer cog to implement a leaderboard. The info.json will have to be updated with proper end_user_statement and there are some things that should be changed. But I hope you like it.

This addition adds a new command:
`[p]trleaderboard`
which shows the top 10 highest WPM.