### PR TITLE
[docs] Missing Blocks ImportError

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
+rapidfuzz
 recommonmark
 Red-DiscordBot
 Sphinx


### PR DESCRIPTION
Fixes an import error causing certain blocks to fail to appear. Specifically, the react and delete block now appear on [this build](https://phen-cogs--105.org.readthedocs.build/en/105/tags/parsing_blocks.html#delete-block) whereas they did not appear [previously](https://phen-cogs--104.org.readthedocs.build/en/104/tags/parsing_blocks.html#delete-block).