### PR TITLE
[SlashTags] Fix buttons when skipped dynamically

### DIFF
--- a/slashtags/testing/button_menus.py
+++ b/slashtags/testing/button_menus.py
@@ -194,7 +194,7 @@ class ButtonMenuMixin:
                     raise asyncio.TimeoutError()
 
                 # Exception will propagate if e.g. cancelled or timed out
-                payload = done.pop().result()
+                payload: InteractionButton = done.pop().result()
                 loop.create_task(self.update(payload))
 
                 # NOTE: Removing the reaction ourselves after it's been done when
@@ -249,6 +249,8 @@ class ButtonMenuMixin:
         if not button:
             return
         if not self._running:
+            return
+        if not button.skip_if(self):
             return
 
         try:


### PR DESCRIPTION
Bugfix on slashtags, An edge can when "calling" the button could return a None object. 
Reference: [link](https://github.com/Rapptz/discord-ext-menus/blob/master/discord/ext/menus/__init__.py#L206)

Added an extra check to just prematurely close the function. 