### PR TITLE
[SlashTags] Fix `[p]st global edit argument` can't be used for global slashtags

### DIFF
--- a/slashtags/mixins/commands.py
+++ b/slashtags/mixins/commands.py
@@ -636,7 +636,7 @@ class Commands(MixinMeta):
     @slashtag_global_edit.command("argument", aliases=["option"])
     @copy_doc(slashtag_edit_argument)
     async def slashtag_global_edit_argument(
-        self, ctx: commands.Context, tag: GuildTagConverter, argument: str
+        self, ctx: commands.Context, tag: GlobalTagConverter, argument: str
     ):
         await tag.edit_single_option(ctx, argument)
 


### PR DESCRIPTION
I tried `[p]st global edit argument <tag>` recently, but it seems to not found the specified global slashtag, and this can be fixed with this PR.