### PR TITLE
[PfpImgen] Use new api for `[p]petpet`

### DIFF
--- a/pfpimgen/pfpimgen.py
+++ b/pfpimgen/pfpimgen.py
@@ -235,8 +235,8 @@ class PfpImgen(commands.Cog):
         """petpet someone"""
         member = member or ctx.author
         async with ctx.typing():
-            params = {"avatar": str(member.avatar_url_as(format="png"))}
-            url = "https://api.obamabot.ml/v1/image/petpet"
+            params = {"image": str(member.avatar_url_as(format="png"))}
+            url = "https://api.popcat.xyz/pet"
             async with self.session.get(url, params=params) as resp:
                 if resp.status != 200:
                     return await ctx.send(


### PR DESCRIPTION
I see that `https://api.obamabot.ml` is already dead, so I found another free API (`https://api.popcat.xyz`) that can generate petpet GIF, I have test this with InstantCommand and it works well :p