### PR TITLE
[Slashtags] Fix message arg for `ctx.tick()`

### DIFF
--- a/slashtags/objects.py
+++ b/slashtags/objects.py
@@ -630,5 +630,5 @@ class SlashContext(commands.Context):
             invoked_with=interaction.command_name,
         )
 
-    async def tick(self, message: Optional[str] = None):
-        await self.interaction.send(f"✅ {message or ''}", hidden=True)
+    async def tick(self, *, message: Optional[str] = None):
+        await self.interaction.send(message or "✅", hidden=True)

--- a/slashtags/objects.py
+++ b/slashtags/objects.py
@@ -630,5 +630,5 @@ class SlashContext(commands.Context):
             invoked_with=interaction.command_name,
         )
 
-    async def tick(self):
-        await self.interaction.send("✅", hidden=True)
+    async def tick(self, message: Optional[str] = None):
+        await self.interaction.send(f"✅ {message or ''}", hidden=True)


### PR DESCRIPTION
Basically this PR fixes the issue below -
```py
Traceback (most recent call last):
  File "/root/MELON/lib/python3.9/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/root/.local/share/Red-DiscordBot/data/MELON/cogs/CogManager/cogs/giveaways/main.py", line 720, in g_end
    await ctx.tick(message="Giveaway was ended successfully!")
TypeError: tick() got an unexpected keyword argument 'message'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/MELON/lib/python3.9/site-packages/discord/ext/commands/bot.py", line 939, in invoke
    await ctx.command.invoke(ctx)
  File "/root/MELON/lib/python3.9/site-packages/redbot/core/commands/commands.py", line 841, in invoke
    await super().invoke(ctx)
  File "/root/MELON/lib/python3.9/site-packages/discord/ext/commands/core.py", line 1348, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/root/MELON/lib/python3.9/site-packages/discord/ext/commands/core.py", line 863, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/root/MELON/lib/python3.9/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: tick() got an unexpected keyword argument 'message'
```
This error originated from slashtags.