### PR TITLE
Add exception handling for `Interaction Not Found`.

### DIFF
--- a/slashtags/mixins/processor.py
+++ b/slashtags/mixins/processor.py
@@ -167,7 +167,11 @@ class Processor(MixinMeta):
         if content or embed:
             await self.send_tag_response(interaction, actions, content, hidden=hidden, embed=embed)
         else:
-            await interaction.defer(hidden=hidden)
+            try:
+                await interaction.defer(hidden=hidden)
+            except discord.NotFound:
+                pass
+            
 
         if command_task := await self.handle_commands(interaction, actions):
             to_gather.append(command_task)
@@ -176,7 +180,10 @@ class Processor(MixinMeta):
             await asyncio.gather(*to_gather)
 
         if not interaction.completed:
-            await interaction.send("Slash Tag completed.", hidden=True)
+            try:
+                await interaction.send("Slash Tag completed.", hidden=True)
+            except discord.NotFound:
+                pass
 
     async def handle_requires(self, interaction: InteractionCommand, actions: dict):
         try:


### PR DESCRIPTION
Often times, the process_tag function in the Processor mixin takes a while before it reaches to the point where it has to defer/respond to the interaction. This makes it so that the window to respond to the interaction has already passed and causes it to raise `discord.NotFound` exception stating that the interaction was not found. This PR simply adds a try except block around these two interaction calls in order to suppress the errors. 