### PR TITLE
change akinator.py[fast_async] to akinator[fast_async]

### DIFF
--- a/aki/info.json
+++ b/aki/info.json
@@ -8,7 +8,7 @@
         "PhenoM4n4n"
     ],
     "required_cogs": {},
-    "requirements": ["akinator.py[fast_async]"],
+    "requirements": ["akinator[fast_async]"],
     "tags": [
         "fun"
     ],

--- a/aki/info.json
+++ b/aki/info.json
@@ -8,7 +8,7 @@
         "PhenoM4n4n"
     ],
     "required_cogs": {},
-    "requirements": ["akinator[fast_async]"],
+    "requirements": ["akinator[fast_async]==1.0.3"],
     "tags": [
         "fun"
     ],


### PR DESCRIPTION
The library repo had been moved to a new repo and it's now installed without the .py
should close #138 