### PR TITLE
[Baron] fix `build_cache` missing.

### DIFF
--- a/baron/baron.py
+++ b/baron/baron.py
@@ -91,6 +91,9 @@ class Baron(commands.Cog):
     async def red_delete_data_for_user(self, *, requester: RequestType, user_id: int) -> None:
         return
 
+    async def cog_load(self):
+        await self.build_cache()
+
     async def build_cache(self):
         self.settings_cache = await self.config.all()
 

--- a/baron/baron.py
+++ b/baron/baron.py
@@ -91,7 +91,7 @@ class Baron(commands.Cog):
     async def red_delete_data_for_user(self, *, requester: RequestType, user_id: int) -> None:
         return
 
-    async def cog_load(self):
+    async def build_cache(self):
         self.settings_cache = await self.config.all()
 
     @commands.is_owner()


### PR DESCRIPTION
Looks like bc of the last PR I made for the async cog loading, I have had mistakenly changed `build_cache` with `cog_load`, which went un-noticed, and was erroring out the cog.

```py
Exception in command 'baron whitelist'
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.10/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/ubuntu/redbot/cogs/CogManager/cogs/baron/baron.py", line 221, in whitelist
    await self.build_cache()
AttributeError: 'Baron' object has no attribute 'build_cache'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.10/site-packages/discord/ext/commands/bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.10/site-packages/redbot/core/commands/commands.py", line 782, in invoke
    await super().invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.10/site-packages/discord/ext/commands/core.py", line 1642, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.10/site-packages/discord/ext/commands/core.py", line 1023, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
  File "/home/ubuntu/redenv/lib/python3.10/site-packages/discord/ext/commands/core.py", line 238, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'Baron' object has no attribute 'build_cache'
```

This PR fixes the above exception.