### PR TITLE
[BanChart] Handle .bans breakage

### DIFF
--- a/banchart/banchart.py
+++ b/banchart/banchart.py
@@ -66,14 +66,15 @@ class BanChart(commands.Cog):
 
     @staticmethod
     async def get_ban_limit(ctx: commands.Context, limit: int) -> Tuple[int, list]:
-        await ctx.trigger_typing()
-        bans = await ctx.guild.bans()
-        ban_count = len(bans)
-        if not ban_count:
-            raise commands.UserFeedbackCheckFailure("This server has no bans.")
-        limit = min(LIMIT, min(limit, ban_count))
-        await ctx.send(f"Gathering stats up to the last {limit} bans.")
-        return limit, bans
+        async with ctx.typing():
+            limit = min(LIMIT, limit)
+            bans = [entry async for entry in ctx.guild.bans(limit=limit)]
+            ban_count = len(bans)
+            if not ban_count:
+                raise commands.UserFeedbackCheckFailure("This server has no bans.")
+            limit = min(ban_count, limit)
+            await ctx.send(f"Gathering stats up to the last {limit} bans.")
+            return limit, bans
 
     @staticmethod
     def get_name(user: Union[discord.User, int]) -> str:


### PR DESCRIPTION
Discord made a breaking change to how the API handles fetching bans. Now, a similar system to `ctx.history` is used, and dpy returns an async iterable rather than a list. This PR updates the BanChart cog to handle this change. In addition, the `trigger_typing` change from #152 is copied here to avoid breaking that PR (and because that change is also needed for this cog to work).