### PR TITLE
[PfpImgen] fix bonk command

### DIFF
--- a/pfpimgen/pfpimgen.py
+++ b/pfpimgen/pfpimgen.py
@@ -85,7 +85,6 @@ class PfpImgen(commands.Cog):
     @commands.command(cooldown_after_parsing=True)
     async def bonk(self, ctx, *, member: FuzzyMember = None):
         """Bonk! Go to horny jail."""
-        await ctx.trigger_typing()
         bonker = False
         if member:
             bonker = ctx.author


### PR DESCRIPTION
Seems like this line shouldn't be there since `async with ctx.typing():` was added after that