### PR TITLE
Fix `AttributeError: module 'discord' has no attribute 'InvalidArgument'`

### DIFF
--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -239,7 +239,7 @@ class Webhook(commands.Cog):
                     await webhook.delete(
                         reason=f"Mass webhook deletion requested by {ctx.author} ({ctx.author.id})"
                     )
-                except TypeError:
+                except ValueError:
                     pass
                 else:
                     count += 1
@@ -434,7 +434,7 @@ class Webhook(commands.Cog):
                 allowed_mentions=allowed_mentions,
                 **kwargs,
             )
-        except (TypeError, discord.NotFound) as exc:
+        except (ValueError, discord.NotFound) as exc:
             try:
                 del self.link_cache[webhook.id]
             except KeyError:
@@ -517,7 +517,7 @@ class Webhook(commands.Cog):
                 return
             try:
                 return await webhook.send(allowed_mentions=allowed_mentions, **kwargs)
-            except (TypeError, discord.NotFound):
+            except (ValueError, discord.NotFound):
                 del self.channel_cache[channel.id]
                 if index >= 5:
                     log.debug(

--- a/webhook/webhook.py
+++ b/webhook/webhook.py
@@ -239,7 +239,7 @@ class Webhook(commands.Cog):
                     await webhook.delete(
                         reason=f"Mass webhook deletion requested by {ctx.author} ({ctx.author.id})"
                     )
-                except discord.InvalidArgument:
+                except TypeError:
                     pass
                 else:
                     count += 1
@@ -434,7 +434,7 @@ class Webhook(commands.Cog):
                 allowed_mentions=allowed_mentions,
                 **kwargs,
             )
-        except (discord.InvalidArgument, discord.NotFound) as exc:
+        except (TypeError, discord.NotFound) as exc:
             try:
                 del self.link_cache[webhook.id]
             except KeyError:
@@ -517,7 +517,7 @@ class Webhook(commands.Cog):
                 return
             try:
                 return await webhook.send(allowed_mentions=allowed_mentions, **kwargs)
-            except (discord.InvalidArgument, discord.NotFound):
+            except (TypeError, discord.NotFound):
                 del self.channel_cache[channel.id]
                 if index >= 5:
                     log.debug(


### PR DESCRIPTION
Basically fixes this error:
```py
Traceback (most recent call last):
  File "/{SPUNGED}/.local/share/Red-DiscordBot/data/MELON/cogs/CogManager/cogs/webhook/webhook.py", line 519, in send_to_channel
    return await webhook.send(allowed_mentions=allowed_mentions, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/{SPUNGED}/lib/python3.11/site-packages/discord/webhook/async_.py", line 1800, in send
    data = await adapter.execute_webhook(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/{SPUNGED}/lib/python3.11/site-packages/discord/webhook/async_.py", line 219, in request
    raise NotFound(response, data)
discord.errors.NotFound: 404 Not Found (error code: 10015): Unknown Webhook

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/{SPUNGED}/lib/python3.11/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/{SPUNGED}/.local/share/Red-DiscordBot/data/MELON/cogs/CogManager/cogs/webhook/webhook.py", line 159, in webhook_sudo
    await self.send_to_channel(
  File "/{SPUNGED}/.local/share/Red-DiscordBot/data/MELON/cogs/CogManager/cogs/webhook/webhook.py", line 520, in send_to_channel
    except (discord.InvalidArgument, discord.NotFound):
            ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'discord' has no attribute 'InvalidArgument'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/{SPUNGED}/lib/python3.11/site-packages/discord/ext/commands/bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "/{SPUNGED}/melon-dpy2/redbot/core/commands/commands.py", line 783, in invoke
    await super().invoke(ctx)
  File "/{SPUNGED}/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1642, in invoke
    await ctx.invoked_subcommand.invoke(ctx)
  File "/{SPUNGED}/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1023, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/{SPUNGED}/lib/python3.11/site-packages/discord/ext/commands/core.py", line 238, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: module 'discord' has no attribute 'InvalidArgument'
```

https://discordpy.readthedocs.io/en/stable/migrating.html?highlight=invalidargument#removal-of-invalidargument-exception